### PR TITLE
Update runtime, update libraries, drop dconf because unneeded

### DIFF
--- a/ImageMagick.yaml
+++ b/ImageMagick.yaml
@@ -8,6 +8,6 @@ config-opts:
   - --with-png
 sources:
   - type: archive
-    url: https://github.com/ImageMagick/ImageMagick/archive/7.0.8-27.tar.gz
-    sha256: 94866968a447f8f92a969bf5342d612d05a64c71fc75e63bb2d8ecf887dc7fa2
+    url: https://github.com/ImageMagick/ImageMagick/archive/refs/tags/7.0.11-6.tar.gz
+    sha256: 8adc1605784653b078572b825e8cd1d3d54f8a1b4ba86b32ca253c038f7e4c37
 cleanup: ['*']

--- a/XnSketch.yaml
+++ b/XnSketch.yaml
@@ -2,39 +2,21 @@ name: XnSketch
 buildsystem: simple
 sources:
   - type: archive
-    url: https://download.xnview.com/old_versions/XnSketch-118-linux.tgz
-    sha256: bfc35afc4e333db3cc298bffda1f35beca45e8b1b693bc9a45c5bceb161ceae2
-    strip-components: 0
-    only-arches: ['i386']
-  - type: archive
     url: https://download.xnview.com/old_versions/XnSketch-118-linux-x64.tgz
     sha256: 15273b7e38bcac2b4a34034e383547243b3d086ac57259629e49afabe4adace5
     strip-components: 0
-    only-arches: ['x86_64']
   # For missing dependencies
   # /app/XnSketch/XnSketch: error while loading shared libraries: libicui18n.so.54: cannot open shared object file: No such file or directory
   # QLibraryPrivate::loadPlugin failed on "/app/XnSketch/lib/imageformats/libqsvg.so" : "Cannot load library /app/XnSketch/lib/imageformats/libqsvg.so: (libQt5Svg.so.5: cannot open shared object file: No such file or directory)"
   - type: archive
-    url: https://download.xnview.com/old_versions/XnConvert-173-linux.tgz
-    sha256: 4a75dadb22020ed58a7e08e9d522fc3aa8e9f52bd7a4e0bc384774d685d8b01e
-    strip-components: 0
-    only-arches: ['i386']
-  - type: archive
     url: https://download.xnview.com/old_versions/XnConvert-173-linux-x64.tgz
     sha256: fbaf9e284de0973b0338f88ecda525eb5ec4b02f7b6d1305f4dc472aad2778ad
     strip-components: 0
-    only-arches: ['x86_64']
   # Segmentation fault (core dumped)
-  - type: archive
-    url: https://download.xnview.com/old_versions/XnViewMP-083-linux.tgz
-    sha256: 95eac6b118d49e6baaa61e82516004b84ca90adda186e18a5cbd8c2bf2e88235
-    strip-components: 0
-    only-arches: ['i386']
   - type: archive
     url: https://download.xnview.com/old_versions/XnViewMP-083-linux-x64.tgz
     sha256: d4bbc01ca8248e28b36f051aa427f9c9257367284a1130e473c280b66d466d0c
     strip-components: 0
-    only-arches: ['x86_64']
   - type: patch
     path: xnsketch-1.18-wrapper.patch
     strip-components: 0

--- a/com.xnview.XnSketch.yaml
+++ b/com.xnview.XnSketch.yaml
@@ -1,6 +1,6 @@
 app-id: com.xnview.XnSketch
 runtime: org.freedesktop.Platform
-runtime-version: '18.08'
+runtime-version: '20.08'
 sdk: org.freedesktop.Sdk
 command: xnsketch
 finish-args:
@@ -13,11 +13,6 @@ finish-args:
   - --filesystem=home
   # Network access
   #- --share=network
-  # Dconf access
-  - --filesystem=xdg-run/dconf
-  - --filesystem=~/.config/dconf:ro
-  - --talk-name=ca.desrt.dconf
-  - --env=DCONF_USER_CONFIG_DIR=.config/dconf
   # OpenGL access
   - --device=dri
 tags:
@@ -29,6 +24,7 @@ modules:
   # to load PostScript-based file formats (PS + EPS + AI) as well as PDF
   # for display, printing, and conversion
   - ghostscript.yaml
+  - krb5.yaml
   - XnSketch.yaml
 cleanup:
   - /share/man

--- a/ghostscript.yaml
+++ b/ghostscript.yaml
@@ -16,11 +16,10 @@ build-options:
       cppflags: -DPNG_ARM_NEON_OPT=0
 sources:
   - type: archive
-    url: https://github.com/ArtifexSoftware/ghostpdl-downloads/releases/download/gs926/ghostscript-9.26.tar.xz
-    sha256: 90ed475f37584f646e9ef829932b2525d5c6fc2e0147e8d611bc50aa0e718598
-  # Make sure dvipdf is being run securely
-  # https://src.fedoraproject.org/rpms/ghostscript/raw/40935870ead04e622940b8fcb26f6700c280a01a/f/ghostscript-9.23-100-run-dvipdf-securely.patch
-  - type: patch
-    path: ghostscript-9.23-100-run-dvipdf-securely.patch
+    url: https://github.com/ArtifexSoftware/ghostpdl-downloads/releases/download/gs9540/ghostscript-9.54.0.tar.xz
+    sha256: c2b7b43cde600f4e70efb2cd95865f6d884a67315c3de235914697d8ccde6e3b
+  - type: shell
+    commands:
+     - "rm -rf lcms2mt jpeg libpng openjpeg zlib"
 cleanup:
   - /share/doc

--- a/krb5.yaml
+++ b/krb5.yaml
@@ -1,0 +1,10 @@
+name: krb5
+subdir: "src"
+config-opts:
+ - --disable-static
+ - --disable-rpath
+sources:
+ - type: archive
+   url: https://kerberos.org/dist/krb5/1.18/krb5-1.18.3.tar.gz
+   sha256: e61783c292b5efd9afb45c555a80dd267ac67eebabca42185362bee6c4fbd719
+


### PR DESCRIPTION
Fix #2 

This does drop i386 because 20.08 doesn't have a i386 runtime anymore.